### PR TITLE
Pin react-photo-album version to 1.10.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,12 +6,12 @@
   "packages": {
     "": {
       "name": "sanity-plugin-asset-source-unsplash",
-      "version": "0.1.5",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "@sanity/ui": "^0.36.12",
         "react-infinite-scroll-component": "^6.1.0",
-        "react-photo-album": "^1.10.2"
+        "react-photo-album": "1.10.2"
       },
       "devDependencies": {
         "@commitlint/cli": "^7.6.1",

--- a/package.json
+++ b/package.json
@@ -136,6 +136,6 @@
   "dependencies": {
     "@sanity/ui": "^0.36.12",
     "react-infinite-scroll-component": "^6.1.0",
-    "react-photo-album": "^1.10.2"
+    "react-photo-album": "1.10.2"
   }
 }


### PR DESCRIPTION
This PR aims to resolve #11.

**Background**

`react-photo-album` stopped shipping UMD bundle as part of its NPM package in version 1.12.0 (the last version providing UMD bundle is 1.11.1). Based on the issue uncovered in #11, sanity's webpack v3 is unable to handle `react-photo-album`'s ESM bundle. Until sanity's stack is upgraded to a relatively modern webpack version, `react-photo-album`'s version needs to pinned to 1.11.1 or below. With this PR I'm pinning `react-photo-album` to 1.10.2 since this is the version #10 was tested against.

Resolves #11