### PR TITLE
fix!: require `styled-components` v6

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
   "peerDependencies": {
     "react": "^18",
     "sanity": "^3",
-    "styled-components": "^5.2 || ^6"
+    "styled-components": "^6.1"
   },
   "engines": {
     "node": ">=14"

--- a/src/components/Photo.styled.tsx
+++ b/src/components/Photo.styled.tsx
@@ -1,5 +1,5 @@
 import { Card } from '@sanity/ui'
-import styled from 'styled-components'
+import {styled} from 'styled-components'
 
 export const Root = styled.div`
   overflow: hidden;

--- a/src/components/UnsplashAssetSource.styled.tsx
+++ b/src/components/UnsplashAssetSource.styled.tsx
@@ -1,5 +1,5 @@
 import { TextInput } from '@sanity/ui'
-import styled from 'styled-components'
+import {styled} from 'styled-components'
 
 export const SearchInput = styled(TextInput)`
   position: sticky;


### PR DESCRIPTION
Improves compatibility for embedded Studios in modern bundlers like Vite and Turbopack